### PR TITLE
Send debug_info returned from generateFn

### DIFF
--- a/fore/src/client.js
+++ b/fore/src/client.js
@@ -253,11 +253,12 @@ class Foresight {
 			const outputs = {};
 
 			for (const [entryId, query] of Object.entries(queries)) {
-				const { generatedResponse, contexts } = await generateFn(query);
+				const { generatedResponse, contexts, debugInfo } = await generateFn(query);
 
 				outputs[entryId] = {
 					generated_response: generatedResponse,
 					contexts,
+					debug_info: debugInfo
 				};
 			}
 


### PR DESCRIPTION
Support debug_info in JS client, too